### PR TITLE
Add swagger api in articles & search controller

### DIFF
--- a/server/package-lock.json
+++ b/server/package-lock.json
@@ -14,6 +14,7 @@
         "@nestjs/core": "^8.0.0",
         "@nestjs/jwt": "^8.0.0",
         "@nestjs/platform-express": "^8.0.0",
+        "@nestjs/swagger": "^5.2.1",
         "@nestjs/typeorm": "^8.0.3",
         "axios": "^0.25.0",
         "bcrypt": "^5.0.1",
@@ -27,6 +28,7 @@
         "request-promise": "^4.2.6",
         "rimraf": "^3.0.2",
         "rxjs": "^7.2.0",
+        "swagger-ui-express": "^4.3.0",
         "typeorm": "^0.2.41",
         "typeorm-seeding": "^1.6.1"
       },
@@ -1587,6 +1589,25 @@
         "@nestjs/common": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/@nestjs/mapped-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+      "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.8 || ^8.0.0",
+        "class-transformer": "^0.2.0 || ^0.3.0 || ^0.4.0 || ^0.5.0",
+        "class-validator": "^0.11.1 || ^0.12.0 || ^0.13.0",
+        "reflect-metadata": "^0.1.12"
+      },
+      "peerDependenciesMeta": {
+        "class-transformer": {
+          "optional": true
+        },
+        "class-validator": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/@nestjs/platform-express": {
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.2.6.tgz",
@@ -1701,6 +1722,31 @@
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
       "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
       "dev": true
+    },
+    "node_modules/@nestjs/swagger": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.2.1.tgz",
+      "integrity": "sha512-7dNa08WCnTsW/oAk3Ujde+z64JMfNm19DhpXasFR8oJp/9pggYAbYU927HpA+GJsSFJX6adjIRZsCKUqaGWznw==",
+      "dependencies": {
+        "@nestjs/mapped-types": "1.0.1",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^8.0.0",
+        "@nestjs/core": "^8.0.0",
+        "fastify-swagger": "*",
+        "reflect-metadata": "^0.1.12",
+        "swagger-ui-express": "*"
+      },
+      "peerDependenciesMeta": {
+        "fastify-swagger": {
+          "optional": true
+        },
+        "swagger-ui-express": {
+          "optional": true
+        }
+      }
     },
     "node_modules/@nestjs/testing": {
       "version": "8.2.6",
@@ -8787,6 +8833,25 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/swagger-ui-dist": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.10.3.tgz",
+      "integrity": "sha512-eR4vsd7sYo0Sx7ZKRP5Z04yij7JkNmIlUQfrDQgC+xO5ABYx+waabzN+nDsQTLAJ4Z04bjkRd8xqkJtbxr3G7w=="
+    },
+    "node_modules/swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "dependencies": {
+        "swagger-ui-dist": ">=4.1.3"
+      },
+      "engines": {
+        "node": ">= v0.10.32"
+      },
+      "peerDependencies": {
+        "express": ">=4.0.0"
+      }
+    },
     "node_modules/symbol-observable": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/symbol-observable/-/symbol-observable-4.0.0.tgz",
@@ -11558,6 +11623,12 @@
         "jsonwebtoken": "8.5.1"
       }
     },
+    "@nestjs/mapped-types": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/mapped-types/-/mapped-types-1.0.1.tgz",
+      "integrity": "sha512-NFvofzSinp00j5rzUd4tf+xi9od6383iY0JP7o0Bnu1fuItAUkWBgc4EKuIQ3D+c2QI3i9pG1kDWAeY27EMGtg==",
+      "requires": {}
+    },
     "@nestjs/platform-express": {
       "version": "8.2.6",
       "resolved": "https://registry.npmjs.org/@nestjs/platform-express/-/platform-express-8.2.6.tgz",
@@ -11637,6 +11708,16 @@
           "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg==",
           "dev": true
         }
+      }
+    },
+    "@nestjs/swagger": {
+      "version": "5.2.1",
+      "resolved": "https://registry.npmjs.org/@nestjs/swagger/-/swagger-5.2.1.tgz",
+      "integrity": "sha512-7dNa08WCnTsW/oAk3Ujde+z64JMfNm19DhpXasFR8oJp/9pggYAbYU927HpA+GJsSFJX6adjIRZsCKUqaGWznw==",
+      "requires": {
+        "@nestjs/mapped-types": "1.0.1",
+        "lodash": "4.17.21",
+        "path-to-regexp": "3.2.0"
       }
     },
     "@nestjs/testing": {
@@ -17091,6 +17172,19 @@
       "resolved": "https://registry.npmjs.org/supports-preserve-symlinks-flag/-/supports-preserve-symlinks-flag-1.0.0.tgz",
       "integrity": "sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==",
       "dev": true
+    },
+    "swagger-ui-dist": {
+      "version": "4.10.3",
+      "resolved": "https://registry.npmjs.org/swagger-ui-dist/-/swagger-ui-dist-4.10.3.tgz",
+      "integrity": "sha512-eR4vsd7sYo0Sx7ZKRP5Z04yij7JkNmIlUQfrDQgC+xO5ABYx+waabzN+nDsQTLAJ4Z04bjkRd8xqkJtbxr3G7w=="
+    },
+    "swagger-ui-express": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/swagger-ui-express/-/swagger-ui-express-4.3.0.tgz",
+      "integrity": "sha512-jN46SEEe9EoXa3ZgZoKgnSF6z0w3tnM1yqhO4Y+Q4iZVc8JOQB960EZpIAz6rNROrDApVDwcMHR0mhlnc/5Omw==",
+      "requires": {
+        "swagger-ui-dist": ">=4.1.3"
+      }
     },
     "symbol-observable": {
       "version": "4.0.0",

--- a/server/package.json
+++ b/server/package.json
@@ -30,6 +30,7 @@
     "@nestjs/core": "^8.0.0",
     "@nestjs/jwt": "^8.0.0",
     "@nestjs/platform-express": "^8.0.0",
+    "@nestjs/swagger": "^5.2.1",
     "@nestjs/typeorm": "^8.0.3",
     "axios": "^0.25.0",
     "bcrypt": "^5.0.1",
@@ -43,6 +44,7 @@
     "request-promise": "^4.2.6",
     "rimraf": "^3.0.2",
     "rxjs": "^7.2.0",
+    "swagger-ui-express": "^4.3.0",
     "typeorm": "^0.2.41",
     "typeorm-seeding": "^1.6.1"
   },

--- a/server/src/articles/articles.controller.ts
+++ b/server/src/articles/articles.controller.ts
@@ -1,18 +1,30 @@
-import { Body, Controller, Delete, Get, HttpCode, ParseIntPipe, Patch, Post, Query, UseGuards, ValidationPipe } from '@nestjs/common';
+import { Body, Controller, Delete, Get, ParseIntPipe, Patch, Post, Query, UseGuards} from '@nestjs/common';
+import { ApiBadRequestResponse, ApiBearerAuth, ApiBody, ApiCreatedResponse, ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiTags, ApiUnauthorizedResponse } from '@nestjs/swagger';
 import { AuthGuard } from 'src/guards/auth.guard';
 import { ArticlesService } from './articles.service';
 import { CreateArticleDto } from './dto/createArticle.dto';
 import { UpdateArticleDto } from './dto/updateArticle.dto';
+import { CreateArticle400Response, CreateArticle404Response, CreateArticleResponse } from './response/createArticle.response';
+import { DeleteArticle404Response, DeleteArticleResponse } from './response/deleteArticle.response';
+import { GetArticleDetail404Response, GetArticleDetailResponse } from './response/getArticleDetail.response';
+import { GetMain401Response, GetMain404Response, GetMainResponse } from './response/getMain.response';
+import { GetRecent401Response, GetRecent404Response, GetRecentResponse } from './response/getRecent.response';
+import { UpdateArticle400Response, UpdateArticle404Response, UpdateArticleResponse } from './response/updateArticle.response';
 
 @Controller('articles')
+@ApiTags('Articles')
 export class ArticlesController {
   constructor(
     private articlesService: ArticlesService,
   ) {}
 
   @Get()
+  @ApiOperation({summary: "메인 페이지 팔로우 조회", description: "메인 페이지에서 팔로우한 사람의 게시물들을 조회한다."})
+  @ApiOkResponse({description: '팔로우 게시물을 정상적으로 조회함', type: GetMainResponse})
+  @ApiUnauthorizedResponse({description: '권한이 없음', type: GetMain401Response})
+  @ApiNotFoundResponse({description: '팔로잉 유저를 찾을 수 없음', type: GetMain404Response})
+  @ApiBearerAuth()
   @UseGuards(AuthGuard)
-  @HttpCode(200)
   getMain(
     @Query('user', ParseIntPipe) user: number,
     @Query('page', ParseIntPipe) page: number
@@ -21,7 +33,10 @@ export class ArticlesController {
   }
 
   @Get('/recent')
-  @HttpCode(200)
+  @ApiOperation({summary: "메인 페이지 최신순 조회", description: "메인 페이지에서 모든 게시물들을 최신순으로 조회한다."})
+  @ApiOkResponse({description: '최신순으로 게시물을 정상적으로 조회함', type: GetRecentResponse})
+  @ApiUnauthorizedResponse({description: '권한이 없음', type: GetRecent401Response})
+  @ApiNotFoundResponse({description: '팔로잉 유저를 찾을 수 없음', type: GetRecent404Response})
   getRecent(
     @Query('page', ParseIntPipe) page: number
   ): Promise<object> {
@@ -29,7 +44,9 @@ export class ArticlesController {
   }
 
   @Get('/detail')
-  @HttpCode(200)
+  @ApiOperation({summary: "게시물 상세 조회", description: "특정 게시물의 정보를 상세 조회한다."})
+  @ApiOkResponse({description: '게시물 상세정보를 정상적으로 조회함', type: GetArticleDetailResponse})
+  @ApiNotFoundResponse({description: `게시물의 상세 정보를 조회할 수 없음`, type: GetArticleDetail404Response})
   getDetail(
     @Query('id', ParseIntPipe) id: number,
     @Query('user') user?: number
@@ -38,22 +55,33 @@ export class ArticlesController {
   }
 
   @Post()
+  @ApiOperation({summary: "게시물 등록", description: "작성된 게시물을 등록한다."})
+  @ApiCreatedResponse({description: '게시물이 정상적으로 등록됨', type: CreateArticleResponse})
+  @ApiBadRequestResponse({description: '잘못된 요청', type: CreateArticle400Response})
+  @ApiNotFoundResponse({description: `유저 정보를 찾을 수 없음`, type: CreateArticle404Response})
+  @ApiBearerAuth()
   @UseGuards(AuthGuard)
-  @HttpCode(201)
   createArticle(@Body() createArticleDto: CreateArticleDto): Promise<object> {
     return this.articlesService.createArticle(createArticleDto);
   }
 
   @Patch()
+  @ApiOperation({summary: "게시물 수정", description: "게시물을 수정한다."})
+  @ApiOkResponse({description: '게시물이 정상적으로 수정됨', type: UpdateArticleResponse})
+  @ApiNotFoundResponse({description: `게시물 내용을 찾을 수 없음`, type: UpdateArticle404Response})
+  @ApiBadRequestResponse({description: '잘못된 요청으로 작업이 취소됨', type: UpdateArticle400Response})
+  @ApiBearerAuth()
   @UseGuards(AuthGuard)
-  @HttpCode(200)
   updateArticle(@Body() updateArticleDto: UpdateArticleDto): Promise<object> {
     return this.articlesService.updateArticle(updateArticleDto)
   }
 
   @Delete()
+  @ApiOperation({summary: "게시물 삭제", description: "게시물을 삭제한다."})
+  @ApiOkResponse({description: '게시물이 정상적으로 삭제됨', type: DeleteArticleResponse})
+  @ApiNotFoundResponse({description: '삭제할 게시물을 찾을 수 없음', type: DeleteArticle404Response})
+  @ApiBearerAuth()
   @UseGuards(AuthGuard)
-  @HttpCode(200)
   deleteArticle(
     @Query('id', ParseIntPipe) id: number
   ): Promise<object> {

--- a/server/src/articles/articles.service.spec.ts
+++ b/server/src/articles/articles.service.spec.ts
@@ -282,8 +282,6 @@ describe('Articles Service', () => {
       const userId = articles[0].userId;
       const writer = articles[0].nickname;
       const profileImage = articles[0].profileImage;
-      const tagName = articles[0].tags[0];
-      const tagIds = [34];
       const successMessage = 'ok';
       const result = await service.getMain(userId, page);
       expect(followRepository.getFollowingIds).toBeCalledTimes(1);
@@ -312,7 +310,7 @@ describe('Articles Service', () => {
       });
     });
     it('ERROR: 게시물에 대한 정보 조회 중 비정상 종료 시 Not Found Exception 반환.', async () => {
-      const errorMessage = 'Not Found Articles Contents';
+      const errorMessage = 'not found articles contents';
       try {
         articleRepository.getUserId.mockRejectedValue(undefined);
         const result = await service.getMain(userId, page);
@@ -324,28 +322,31 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 팔로잉을 찾을 수 없을 경우 Unauthorized Exception 반환', async () => {
+      const errorMessage = 'permisson denied';
       try {
         followRepository.getFollowingIds.mockResolvedValue(undefined);
         const result = await service.getMain(userId, page);
         expect(result).toBeDefined();
       } catch (err) {
         expect(err.status).toBe(401);
-        expect(err.response.message).toBe('permisson denied');
+        expect(err.response.message).toBe(errorMessage);
       }
     });
 
     it('ERROR: 팔로잉이 0명일 경우 Not Found Exception 반환', async () => {
+      const errorMessage = 'not found following ids'
       try {
         followRepository.getFollowingIds.mockResolvedValue([]);
         const result = await service.getMain(userId, page);
         expect(result).toBeDefined();
       } catch (err) {
         expect(err.status).toBe(404);
-        expect(err.response.message).toBe('cannot find articles');
+        expect(err.response.message).toBe(errorMessage);
       }
     });
 
     it('ERROR: 팔로워의 게시물이 0개일 경우 Not Found Exception 반환', async () => {
+      const errorMessage = 'not found articles'
       try {
         articleRepository.getArticleInfo.mockResolvedValue([]);
         const result = await service.getMain(userId, page);
@@ -353,7 +354,7 @@ describe('Articles Service', () => {
       } catch (err) {
         console.log(err);
         expect(err.status).toBe(404);
-        expect(err.response.message).toBe('');
+        expect(err.response.message).toBe(errorMessage);
       }
     });
   });
@@ -399,18 +400,19 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물이 없을 경우 Not Found Exception 반환', async () => {
+      const errorMessage = 'not found articles'
       try {
         articleRepository.getArticleInfo.mockResolvedValue(undefined);
         const result = await service.getRecent(page);
         expect(result).toBeDefined();
       } catch (err) {
         expect(err.status).toBe(404);
-        expect(err.response.message).toBe('cannot find articless');
+        expect(err.response.message).toBe(errorMessage);
       }
     });
 
     it('ERROR: 게시물에 대한 정보 조회 중 비정상 종료 시 Not Found Exception 반환.', async () => {
-      const errorMessage = 'Not Found Articles Contents';
+      const errorMessage = 'not found articles contents';
       try {
         articleRepository.getUserId.mockRejectedValue(undefined);
         const result = await service.getRecent(1);
@@ -488,7 +490,7 @@ describe('Articles Service', () => {
           order: 1,
         },
       ];
-      const errorMessage = 'Not Found Tags';
+      const errorMessage = 'not found tags';
       try {
         tagRepository.findOne.mockRejectedValue(undefined);
         const result = await service.findOrCreateTags(articleId, tag);
@@ -535,17 +537,19 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 유저 정보가 없을 경우 Not Found Exception 반환', async () => {
+      const errorMessage = `not found user's information`;
       try {
         userRepository.findOne.mockReturnValue(undefined);
         const result = await service.createArticle(createArticleDto);
         expect(result).toBeDefined();
       } catch (err) {
         expect(err.status).toBe(404);
-        expect(err.response.message).toBe('cannot find user');
+        expect(err.response.message).toBe(errorMessage);
       }
     });
 
     it('ERROR: 게시물 생성이 비정상적으로 종료될 경우 생성된 게시물 삭제 및 Bad Request Exception 반환', async () => {
+      const errorMessage = 'bad request'
       const userInfo = { id: 5, nickname: 'test', profileImage: 'profile.jpg' };
       const articleResult = createdArticle.data.articleInfo;
       try {
@@ -556,7 +560,7 @@ describe('Articles Service', () => {
         expect(result).toBeDefined();
       } catch (err) {
         expect(err.status).toBe(400);
-        expect(err.response.message).toBe('bad request');
+        expect(err.response.message).toBe(errorMessage);
         expect(articleRepository.deleteArticle).toBeCalledTimes(1);
         expect(articleRepository.deleteArticle).toBeCalledWith(
           articleResult.id,
@@ -584,7 +588,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물 정보를 찾을 수 없을 경우 Not Found Exception 반환.', async () => {
-      const errorMessage = `Not Found The Article's Contents`;
+      const errorMessage = `not found the article's contents`;
       try {
         articleRepository.getArticleDetail.mockResolvedValue(undefined);
         const result = await service.getArticleDetail(articleId, userId);
@@ -596,7 +600,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물에 대한 유저정보를 찾을 수 없을 경우 Not Found Exception 반환.', async () => {
-      const errorMessage = `Not Found User's Information`;
+      const errorMessage = `not found user's information`;
       try {
         userRepository.getUserInfo.mockResolvedValue(undefined);
         const result = await service.getArticleDetail(articleId, userId);
@@ -608,7 +612,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물에 대한 태그 정보를 찾을 수 없을 경우 Not Found Exception 반환.', async () => {
-      const errorMessage = `Not Found Tags`;
+      const errorMessage = `not found tags`;
       try {
         articleToTagRepository.getTagIds.mockResolvedValue(undefined);
         const result = await service.getArticleDetail(articleId, userId);
@@ -620,7 +624,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물에 대한 경로 정보를 찾을 수 없을 경우 Not Found Exception 반환.', async () => {
-      const errorMessage = `Not Found Article's Roads`;
+      const errorMessage = `not found article's roads`;
       try {
         trackRepository.getRoads.mockResolvedValue(undefined);
         const result = await service.getArticleDetail(articleId, userId);
@@ -673,7 +677,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물 정보가 조회가 불가능 할 경우 Not Found Exception 반환', async () => {
-      const errorMessage = `Not Found Article's Contents`;
+      const errorMessage = `not found article's contents`;
       try {
         articleRepository.findOne.mockResolvedValue(undefined);
         const result = await service.updateArticle(updateArticleDto);
@@ -697,7 +701,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물을 작성한 유저 정보를 찾을 수 없을 경우 Not Found Exception 반환', async () => {
-      const errorMessage = 'Not Found User Information';
+      const errorMessage = 'not found user information';
       const dto = {
         ...updateArticleDto,
         user: 5,
@@ -714,7 +718,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 기존 게시물에 대한 태그를 찾을 수 없을 경우 Not Found Exception 반환', async () => {
-      const errorMessage = 'Not Found Tags';
+      const errorMessage = 'not found tags';
       const dto = {
         ...updateArticleDto,
         user: 5,
@@ -731,7 +735,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 게시물에 대한 경로 정보를 찾을 수 없을 경우 Not Found Exception 반환', async () => {
-      const errorMessage = `Not Found Article's Roads`;
+      const errorMessage = `not found article's roads`;
       const dto = {
         ...updateArticleDto,
         user: 5,
@@ -748,7 +752,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 기존 태그 삭제가 비정상적으로 종료될 경우 기존 작업 취소 및 Bad Request Exception 반환', async () => {
-      const errorMessage = 'Bad Request, A Task was cancelled';
+      const errorMessage = 'bad request, a task was cancelled';
       const dto = {
         ...updateArticleDto,
         user: 5,
@@ -767,7 +771,7 @@ describe('Articles Service', () => {
     });
 
     it('ERROR: 신규 태그 생성 작업이 비정상적으로 종료될 경우 기존 작업 취소 및 Bad Request Exception 반환', async () => {
-      const errorMessage = 'Bad Request, A Task was cancelled';
+      const errorMessage = 'bad request, a task was cancelled';
       const dto = {
         ...updateArticleDto,
         user: 5,
@@ -789,16 +793,16 @@ describe('Articles Service', () => {
 
   describe('7. deleteArticle 테스트', () => {
     it('SUCCESS: 게시물 삭제가 정상적으로 완료됨', async () => {
-      const successMessage = { message: 'article deleted' };
+      const successMessage = 'article deleted';
       articleRepository.deleteArticle.mockResolvedValue('success');
       const result = await service.deleteArticle(articleId);
       expect(articleRepository.deleteArticle).toBeCalledTimes(1);
       expect(articleRepository.deleteArticle).toBeCalledWith(articleId);
-      expect(result).toEqual(successMessage);
+      expect(result.message).toEqual(successMessage);
     });
 
     it('ERROR: 삭제할 게시물을 찾지 못하면 Not Found Exception 반환', async () => {
-      const errorMessage = 'Not Found Article you wanted to delete';
+      const errorMessage = 'not found article you wanted to delete';
       try {
         const unknownUserId = 105;
         articleRepository.deleteArticle.mockResolvedValue(null);

--- a/server/src/articles/articles.service.ts
+++ b/server/src/articles/articles.service.ts
@@ -42,7 +42,7 @@ export class ArticlesService {
     if (!getFollowing) {
       throw new UnauthorizedException('permisson denied');
     } else if (getFollowing.length === 0) {
-      throw new NotFoundException('cannot find articles');
+      throw new NotFoundException('not found following ids');
     }
 
     const newArticles = [];
@@ -55,8 +55,7 @@ export class ArticlesService {
     );
 
     if (!articles || articles.length === 0) {
-      const error = new NotFoundException('cannot find articles');
-      return error;
+      throw new NotFoundException('not found articles');
     }
 
     try {
@@ -111,7 +110,7 @@ export class ArticlesService {
         message: 'ok',
       };
     } catch (err) {
-      throw new NotFoundException('Not Found Articles Contents');
+      throw new NotFoundException('not found articles contents');
     }
   }
 
@@ -125,8 +124,7 @@ export class ArticlesService {
     );
 
     if (!articles || articles.length === 0) {
-      const error = new NotFoundException('cannot find articles');
-      return error;
+      throw new NotFoundException('not found articles');
     }
 
     let newArticles = [];
@@ -184,7 +182,7 @@ export class ArticlesService {
         message: 'ok',
       };
     } catch (err) {
-      throw new NotFoundException('Not Found Articles Contents');
+      throw new NotFoundException('not found articles contents');
     }
   }
 
@@ -215,7 +213,7 @@ export class ArticlesService {
         }),
       );
     } catch (err) {
-      throw new NotFoundException('Not Found Tags');
+      throw new NotFoundException('not found tags');
     }
   }
 
@@ -226,7 +224,10 @@ export class ArticlesService {
       select: ['id', 'nickname', 'profileImage'],
     });
 
-    if (!userInfo) throw new NotFoundException('cannot find user');
+    if (!userInfo) {
+      throw new NotFoundException(`not found user's information`);
+    }
+
     const articleResult = await this.articleRepository.createArticle(
       user,
       content,
@@ -259,10 +260,10 @@ export class ArticlesService {
   async getArticleDetail(id: number, user?: number): Promise<any> {
     const articleInfo = await this.articleRepository.getArticleDetail(id);
     if (!articleInfo)
-      throw new NotFoundException(`Not Found The Article's Contents`);
+      throw new NotFoundException(`not found the article's contents`);
 
     const userInfo = await this.userRepository.getUserInfo(articleInfo.userId);
-    if (!userInfo) throw new NotFoundException(`Not Found User's Information`);
+    if (!userInfo) throw new NotFoundException(`not found user's information`);
 
     const likedOrNot = await this.likesRepository.likeOrNot(
       user || undefined,
@@ -270,7 +271,7 @@ export class ArticlesService {
     );
     const tagIds = await this.articleToTagRepository.getTagIds(articleInfo.id);
     if (!tagIds || tagIds.length === 0)
-      throw new NotFoundException(`Not Found Tags`);
+      throw new NotFoundException(`not found tags`);
 
     let tagNames = [];
     for (let tagId of tagIds) {
@@ -280,7 +281,7 @@ export class ArticlesService {
 
     const roads = await this.trackRepository.getRoads(articleInfo.id);
     if (!roads || roads.length === 0)
-      throw new NotFoundException(`Not Found Article's Roads`);
+      throw new NotFoundException(`not found article's roads`);
     let article = {};
     article = {
       id: articleInfo.id,
@@ -315,7 +316,7 @@ export class ArticlesService {
       select: ['id', 'content', 'totalComment', 'totalLike', 'userId'],
     });
     if (!articleInfo)
-      throw new NotFoundException(`Not Found Article's Contents`);
+      throw new NotFoundException(`not found article's contents`);
 
     if (user !== articleInfo.userId)
       throw new ForbiddenException('permission denied');
@@ -329,7 +330,7 @@ export class ArticlesService {
     });
     if (!userInfo) {
       this.articleRepository.update(articleId, {content: articleInfo.content});
-      throw new NotFoundException('Not Found User Information');
+      throw new NotFoundException('not found user information');
     }
 
     const lastTags: Array<any> = await this.articleToTagRepository.find({
@@ -340,13 +341,13 @@ export class ArticlesService {
       this.articleRepository.update(articleId, {
         content: articleInfo.content,
       });
-      throw new NotFoundException('Not Found Tags');
+      throw new NotFoundException('not found tags');
     }
 
     const roads = await this.trackRepository.getRoads(articleId);
     if (!roads || roads.length === 0) {
       this.articleRepository.update(articleId, {content: articleInfo.content});
-      throw new NotFoundException(`Not Found Article's Roads`);
+      throw new NotFoundException(`not found article's roads`);
     }
 
     const deleteTagsResult = await this.articleToTagRepository.deleteTags(articleId);
@@ -356,7 +357,7 @@ export class ArticlesService {
       lastTags.forEach(({ tagId, order }) => {
         this.articleToTagRepository.save({ tagId, articleId, order });
       });
-      throw new BadRequestException('Bad Request, A Task was cancelled');
+      throw new BadRequestException('bad request, a task was cancelled');
     }
     
     const findOrCreateTagsResult = await this.findOrCreateTags(articleId, tag);
@@ -366,7 +367,7 @@ export class ArticlesService {
       lastTags.forEach(({ tagId, order }) => {
         this.articleToTagRepository.save({ tagId, articleId, order });
       });
-      throw new BadRequestException('Bad Request, A Task was cancelled');
+      throw new BadRequestException('bad request, a task was cancelled');
     }
     return {
       data: {
@@ -383,7 +384,7 @@ export class ArticlesService {
   async deleteArticle(id: number) {
     const result = await this.articleRepository.deleteArticle(id);
     if (!result) {
-      throw new NotFoundException('Not Found Article you wanted to delete');
+      throw new NotFoundException('not found article you wanted to delete');
     } else {
       return {
         message: 'article deleted',

--- a/server/src/articles/dto/createArticle.dto.ts
+++ b/server/src/articles/dto/createArticle.dto.ts
@@ -1,26 +1,33 @@
-import { IsArray, IsNotEmpty, IsNumber, isObject, IsObject, IsString } from "class-validator";
+import { ApiProperty } from "@nestjs/swagger";
+import { IsArray, IsNotEmpty, IsNumber, IsString } from "class-validator";
 
 export class CreateArticleDto {
+  @ApiProperty({description: '유저ID'})
   @IsNotEmpty()
   @IsNumber()
   user: number;
 
+  @ApiProperty({description: '경로'})
   @IsNotEmpty()
   @IsArray()
   road: Object[];
 
+  @ApiProperty({description: '태그'})
   @IsNotEmpty()
   @IsArray()
   tag?: Object[];
 
+  @ApiProperty({description: '본문'})
   @IsNotEmpty()
   @IsString()
   content: string;
 
+  @ApiProperty({description: '썸네일'})
   @IsNotEmpty()
   @IsString()
   thumbnail: string;
 
+  @ApiProperty({description: '로그인 방식'})
   @IsNotEmpty()
   @IsNumber()
   loginMethod: number;

--- a/server/src/articles/dto/updateArticle.dto.ts
+++ b/server/src/articles/dto/updateArticle.dto.ts
@@ -1,22 +1,28 @@
+import { ApiProperty, ApiPropertyOptional } from "@nestjs/swagger";
 import { IsArray, IsNotEmpty, IsNumber, IsOptional, IsString } from "class-validator";
 
 export class UpdateArticleDto {
+  @ApiProperty({description: '로그인 방식'})
   @IsNotEmpty()  
   @IsNumber()
   loginMethod: number;
 
+  @ApiProperty({description: '유저ID'})
   @IsNotEmpty()
   @IsNumber()
   user: number;
 
+  @ApiProperty({description: '게시물ID'})
   @IsNotEmpty()
   @IsNumber()
   articleId: number;
 
+  @ApiPropertyOptional({description: '본문'})
   @IsOptional()
   @IsString()
   content?: string;
   
+  @ApiPropertyOptional({description: '태그', type: [Object]})
   @IsOptional()
   @IsArray()
   tag?: [] | object[];

--- a/server/src/articles/response/createArticle.response.ts
+++ b/server/src/articles/response/createArticle.response.ts
@@ -1,0 +1,36 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ArticleInfo, UserInfo } from "./getArticleDetail.response";
+
+export abstract class CreateArticleInfo extends ArticleInfo {
+  constructor() {
+    super()
+  }
+  @ApiProperty({isArray: true})
+  comments: []
+}
+
+export abstract class CreateArticleResponseData {
+  @ApiProperty()
+  userInfo: UserInfo
+
+  @ApiProperty()
+  articleInfo: CreateArticleInfo
+}
+
+export abstract class CreateArticleResponse {
+  @ApiProperty()
+  data: CreateArticleResponseData
+
+  @ApiProperty({example: "ok"})
+  message: string
+}
+
+export abstract class CreateArticle400Response {
+  @ApiProperty({example: "bad request"})
+  message: string
+}
+
+export abstract class CreateArticle404Response {
+  @ApiProperty({example: "not found user's information"})
+  message: string
+}

--- a/server/src/articles/response/deleteArticle.response.ts
+++ b/server/src/articles/response/deleteArticle.response.ts
@@ -1,0 +1,11 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export abstract class DeleteArticleResponse {
+  @ApiProperty({example: 'article deleted'})
+  message: string
+}
+
+export abstract class DeleteArticle404Response {
+  @ApiProperty({example: 'not found article you wanted to delete'})
+  message: string
+}

--- a/server/src/articles/response/getArticleDetail.response.ts
+++ b/server/src/articles/response/getArticleDetail.response.ts
@@ -1,0 +1,80 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { Double } from "typeorm"
+
+export abstract class Road {
+  @ApiProperty({example: "test_image.jpg"})
+  imageSrc: string
+  
+  @ApiProperty({example: "테스트 장소"})
+  placeName: string
+
+  @ApiProperty({example: "테스트 주소"})
+  addressName: string
+
+  @ApiProperty({example: "153.332", type: Double})
+  x: number
+
+  @ApiProperty({example: "32.335", type: Double})
+  y: number
+
+}
+export abstract class ArticleInfo {
+  @ApiProperty({example: 5})
+  id: number
+
+  @ApiProperty({example: "thumnail.jpg"})
+  thumbnail: string
+
+  @ApiProperty({example: "Test본문"})
+  content: string
+
+  @ApiProperty({example: 0})
+  totalLike: number
+
+  @ApiProperty({example: 0})
+  totalComment: number
+
+  @ApiProperty({example: true})
+  likedOrNot: boolean
+
+  @ApiProperty({example: '2022/04/01'})
+  createdAt: Date
+
+  @ApiProperty({example: ["테스트", "엽기"], isArray: true})
+  tags: []
+  
+  @ApiProperty()
+  roads: Road
+}
+
+export abstract class UserInfo {
+  @ApiProperty()
+  id: number
+
+  @ApiProperty()
+  nickname: string
+
+  @ApiProperty()
+  profileImage: string
+}
+
+export abstract class GetArticleDetailResponseData {
+  @ApiProperty()
+  userInfo: UserInfo
+  
+  @ApiProperty()
+  articleInfo: ArticleInfo
+}
+
+export abstract class GetArticleDetailResponse {
+  @ApiProperty()
+  data: GetArticleDetailResponseData
+  
+  @ApiProperty({example: 'ok'})
+  message: string
+}
+
+export abstract class GetArticleDetail404Response {
+  @ApiProperty({example: `not found the article's contents`})
+  message: string
+}

--- a/server/src/articles/response/getMain.response.ts
+++ b/server/src/articles/response/getMain.response.ts
@@ -1,0 +1,50 @@
+import { ApiProperty } from "@nestjs/swagger";
+
+export abstract class ArticleObject {
+  @ApiProperty({example: 5})
+  id: number
+  
+  @ApiProperty({example: 3})
+  userId: number
+
+  @ApiProperty({example: 'thumbnail.jpg'})
+  thumbnail: string
+
+  @ApiProperty({example: "테스트 계정"})
+  nickname: string
+
+  @ApiProperty({example: "profile.jpg"})
+  profileImage: string
+  
+  @ApiProperty({example: 3})
+  totalLike: number
+
+  @ApiProperty({example: 5})
+  totalComment: number
+  
+  @ApiProperty({example: {order: 1, tagName: "테스트"}})
+  tags: Object[] | []
+};
+
+export abstract class ArticlesData {
+  @ApiProperty()
+  articles: ArticleObject
+};
+
+export abstract class GetMainResponse {
+  @ApiProperty()
+  data: ArticlesData
+  
+  @ApiProperty({example: "ok"})
+  message: string
+}
+
+export abstract class GetMain401Response {
+  @ApiProperty({example: 'permisson denied'})
+  message: string
+}
+
+export abstract class GetMain404Response {
+  @ApiProperty({example: 'not found following ids'})
+  message: string
+}

--- a/server/src/articles/response/getRecent.response.ts
+++ b/server/src/articles/response/getRecent.response.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from "@nestjs/swagger"
+import { ArticlesData } from "./getMain.response"
+
+export abstract class GetRecentResponse {
+  @ApiProperty()
+  data: ArticlesData
+  
+  @ApiProperty({example: "ok"})
+  message: string
+}
+
+export abstract class GetRecent401Response {
+  @ApiProperty({example: 'permisson denied'})
+  message: string
+}
+
+export abstract class GetRecent404Response {
+  @ApiProperty({example: 'not found following ids'})
+  message: string
+}

--- a/server/src/articles/response/updateArticle.response.ts
+++ b/server/src/articles/response/updateArticle.response.ts
@@ -1,0 +1,48 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { Road, UserInfo } from "./getArticleDetail.response";
+
+export abstract class UpdateArticleInfo {
+  @ApiProperty({example: 5})
+  id: number
+  
+  @ApiProperty({example: "테스트 본문"})
+  content: string 
+  
+  @ApiProperty({example: 0})
+  totalComment: number 
+  
+  @ApiProperty({example: 3})
+  totalLike: number 
+  
+  @ApiProperty({example: 5})
+  userId: number
+
+  @ApiProperty()
+  roads: Road
+}
+
+export abstract class UpdateArticleResponseData {
+  @ApiProperty()
+  userInfo: UserInfo
+
+  @ApiProperty()
+  articleInfo: UpdateArticleInfo
+}
+
+export abstract class UpdateArticleResponse {
+  @ApiProperty()
+  data: UpdateArticleResponseData
+
+  @ApiProperty({example: "ok"})
+  message: string
+}
+
+export abstract class UpdateArticle400Response {
+  @ApiProperty({example: "bad request, a task was cancelled"})
+  message: string
+}
+
+export abstract class UpdateArticle404Response {
+  @ApiProperty({example: "not found article's contents"})
+  message: string
+}

--- a/server/src/comments/comments.controller.ts
+++ b/server/src/comments/comments.controller.ts
@@ -1,8 +1,10 @@
 import { Body, Controller, Post, Patch, Delete, HttpCode, Query, UseGuards, ParseIntPipe, Get } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from 'src/guards/auth.guard';
 import { CommentsService } from './comments.service';
 import { CreateCommentDto, ModifyCommentDto } from './dto/comments.dto';
 
+@ApiTags('Comments')
 @Controller('comments')
 export class CommentsController {
   constructor(private commentsService: CommentsService) {}

--- a/server/src/follow/follow.controller.ts
+++ b/server/src/follow/follow.controller.ts
@@ -1,8 +1,10 @@
 import { Body, Controller, Get, HttpCode, ParseIntPipe, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from 'src/guards/auth.guard';
 import { FollowDto } from './dto/follow.dto';
 import { FollowService } from './follow.service';
 
+@ApiTags('Follow')
 @Controller('follow')
 export class FollowController {
   constructor(private followService: FollowService) {}

--- a/server/src/likes/likes.controller.ts
+++ b/server/src/likes/likes.controller.ts
@@ -2,7 +2,9 @@ import { Body, Controller, HttpCode, Post, UseGuards } from '@nestjs/common';
 import { LikesService } from './likes.service';
 import { LikesDto } from './dto/likes.dto';
 import { AuthGuard } from 'src/guards/auth.guard';
+import { ApiTags } from '@nestjs/swagger';
 
+@ApiTags('Likes')
 @Controller('likes')
 export class LikesController {
   constructor(private likesService: LikesService) {}

--- a/server/src/main.ts
+++ b/server/src/main.ts
@@ -2,11 +2,25 @@ import { ValidationPipe } from '@nestjs/common';
 import { NestFactory } from '@nestjs/core';
 import { AppModule } from './app.module';
 import * as cookieParser from 'cookie-parser';
+import { DocumentBuilder, SwaggerModule } from '@nestjs/swagger';
 require('dotenv').config();
 
 async function bootstrap() {
   const app = await NestFactory.create(AppModule, {
     cors: true,
+  });
+  
+  const config = new DocumentBuilder()
+  .setTitle('Roadgram')
+  .setDescription('Roadgram API Document')
+  .setVersion('1.0')
+  .addTag('roadgram')
+  .build();
+
+  const document = SwaggerModule.createDocument(app, config);
+  
+  SwaggerModule.setup('api', app, document, {
+    swaggerOptions: {defaultModelsExpandDepth: -1}
   });
 
   app.useGlobalPipes(

--- a/server/src/search/response/searchArticle.response.ts
+++ b/server/src/search/response/searchArticle.response.ts
@@ -1,0 +1,20 @@
+import { ApiProperty } from "@nestjs/swagger";
+import { ArticleObject } from "src/articles/response/getMain.response";
+
+export abstract class SearchArticleResponseData {
+  @ApiProperty()
+  articles: ArticleObject
+}
+
+export abstract class SearchArticleResponse {
+  @ApiProperty()
+  data: SearchArticleResponseData
+  
+  @ApiProperty({example: "ok"})
+  message: string
+}
+
+export abstract class SearchArticle404Response {
+  @ApiProperty({example: "not found tag"})
+  message: string
+}

--- a/server/src/search/search.controller.ts
+++ b/server/src/search/search.controller.ts
@@ -1,10 +1,16 @@
 import { Controller, Get, Query } from '@nestjs/common';
+import { ApiNotFoundResponse, ApiOkResponse, ApiOperation, ApiResponse, ApiTags } from '@nestjs/swagger';
+import { SearchArticle404Response, SearchArticleResponse } from './response/searchArticle.response';
 import { SearchService } from './search.service';
 
+@ApiTags('Search')
 @Controller('search')
 export class SearchController {
   constructor(private searchService: SearchService){}
   @Get()
+  @ApiOperation({summary: "태그 연관 게시물 조회", description: "유저가 입력한 태그와 연관된 게시물을 조회한다."})
+  @ApiOkResponse({description: "입력된 태그 연관 게시물을 정상적으로 조회함", type: SearchArticleResponse})
+  @ApiNotFoundResponse({description: "태그 정보를 찾을 수 없음", type: SearchArticle404Response})
   searchArticle(
     @Query('tag') tag: string,
     @Query('page') page: number

--- a/server/src/search/search.service.spec.ts
+++ b/server/src/search/search.service.spec.ts
@@ -126,7 +126,7 @@ describe('Search Service', () => {
     });
 
     it('ERROR: 검색할 태그가 존재하지 않으면 Not Found Exception 반환.', async () => {
-      const errorMessage = 'cannot find tag';
+      const errorMessage = 'not found tag';
       try {
         tagRepository.getTagId.mockResolvedValueOnce(undefined);
         const result = await service.searchArticle(tag, page);
@@ -138,7 +138,7 @@ describe('Search Service', () => {
     });
 
     it('ERROR: 해당 태그를 가진 게시물이 존재하지 않으면 Not Found Exception 반환.', async () => {
-      const errorMessage = 'cannot find articles';
+      const errorMessage = 'not found articles';
       try {
         articleToTagRepository.getArticleIds.mockResolvedValueOnce(undefined);
         const result = await service.searchArticle(tag, page);
@@ -150,7 +150,7 @@ describe('Search Service', () => {
     });
 
     it('ERROR: 게시물에 대한 정보 조회 중 비정상 종료 시 Not Found Exception 반환.', async () => {
-      const errorMessage = 'Not Found Articles Contents';
+      const errorMessage = `not found article's contents`;
       try {
         articleRepository.getUserId.mockRejectedValue(undefined);
         const result = await service.searchArticle(tag, page);

--- a/server/src/search/search.service.ts
+++ b/server/src/search/search.service.ts
@@ -29,15 +29,13 @@ export class SearchService {
     const tagId = await this.tagRepository.getTagId(tag);
 
     if (!tagId) {
-      const error = new NotFoundException('cannot find tag');
-      return error;
+      throw new NotFoundException('not found tag');
     }
 
     const articleIds = await this.articleToTagRepository.getArticleIds(tagId);
 
     if (!articleIds || articleIds.length === 0) {
-      const error = new NotFoundException('cannot find articles');
-      return error;
+      throw new NotFoundException('not found articles');
     }
 
     const articles = await this.articleRepository.searchArticle(
@@ -97,7 +95,7 @@ export class SearchService {
         message: 'ok',
       };
     } catch (err) {
-      throw new NotFoundException('Not Found Articles Contents');
+      throw new NotFoundException(`not found article's contents`);
     }
   }
 }

--- a/server/src/users/users.controller.ts
+++ b/server/src/users/users.controller.ts
@@ -1,10 +1,12 @@
 import { Body, Controller, Delete, Get, Headers, HttpCode, Patch, Post, Query, UseGuards } from '@nestjs/common';
+import { ApiTags } from '@nestjs/swagger';
 import { AuthGuard } from 'src/guards/auth.guard';
 import { CreateUserDto } from './dto/createUser.dto';
 import { EmailDto, IdDto, KakaoLoginDto, LoginDto, NicknameDto, QueryDto, TokenDto } from './dto/login.dto';
 import { UpdateUserDto } from './dto/updateUser.dto';
 import { UsersService } from './users.service';
 
+@ApiTags('Users')
 @Controller('users')
 export class UsersController {
     constructor(private usersService: UsersService) { }


### PR DESCRIPTION
- swagger api 적용 
 1) 모든 api에 대한 swagger api tags 적용 (문서상 분류를 위해)
 2) Articles, Search api에 대해서 우선 기능 적용(명세, 입력값, 응답 등) 

*  추후 작업 진행 예정
 1) 다른 API들은 분리하여 적용 예정
 2) 추후 동일한 HTTP 응답 구현 필요 (ex: 404 응답 여러 개 등록)
 3) 배열 내 객체 응답에 대한 구현 필요
